### PR TITLE
Added scent customization of paths to watch

### DIFF
--- a/sniffer/main.py
+++ b/sniffer/main.py
@@ -32,9 +32,9 @@ def run(sniffer_instance=None, wait_time=0.5, clear=True, args=(), debug=False):
         sniffer_instance = ScentSniffer()
 
     if debug:
-        scanner = Scanner(('.',), logger=sys.stdout)
+        scanner = Scanner(sniffer_instance.watch_paths, logger=sys.stdout)
     else:
-        scanner = Scanner(('.',))
+        scanner = Scanner(sniffer_instance.watch_paths)
     #sniffer = sniffer_cls(tuple(args), clear, debug)
     sniffer_instance.set_up(tuple(args), clear, debug)
 

--- a/sniffer/runner.py
+++ b/sniffer/runner.py
@@ -37,6 +37,7 @@ class Sniffer(object):
         self._scanners = []
         self.pass_colors = {'fg': white, 'bg': bg_green}
         self.fail_colors = {'fg': white, 'bg': bg_red}
+        self.watch_paths = ('.',)
         self.set_up()
 
     def set_up(self, test_args=(), clear=True, debug=False):
@@ -135,6 +136,7 @@ class ScentSniffer(Sniffer):
             self.pass_colors['bg'] = self.scent.bg_pass
             self.fail_colors['fg'] = self.scent.fg_fail
             self.fail_colors['bg'] = self.scent.bg_fail
+            self.watch_paths = self.scent.watch_paths
 
     def refresh_scent(self, filepath):
         if self.scent and filepath == self.scent.filename:

--- a/sniffer/scent_picker.py
+++ b/sniffer/scent_picker.py
@@ -54,6 +54,11 @@ class ScentModule(object):
     def bg_fail(self):
         return getattr(self.mod, 'fail_bg_color', termstyle.bg_red)
 
+    @property
+    def watch_paths(self):
+        return getattr(self.mod, 'watch_paths', ('.',))
+
+
 def load_file(filename):
     "Runs the given scent.py file."
     mod_name = '.'.join(os.path.basename(filename).split('.')[:-1])


### PR DESCRIPTION
# Motivation/Summary

I need sniffer to watch more than just current directory.
Therefore, made Sniffer recognize `watch_paths` from scent file.
# Changes
- Added property `ScentModule.watch_paths`
- Set attribute `ScentSniffer.watch_paths`. It looks for
  `ScentModule.watch_paths` and defaults to current directory.
- Used `ScentSniffer.watch_paths` in `main.run` instead of current
  directory.
