### PR TITLE
Support Python 3.3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Testing',
         'Topic :: Software Development :: Libraries',
     ],

--- a/sniffer/__init__.py
+++ b/sniffer/__init__.py
@@ -21,9 +21,9 @@ The library to install is dependent on your operating system:
  - OSX: install MacFSEvents
 
 """
-from metadata import *
-from scanner import Scanner
-from runner import Sniffer
-from main import main, run
+from .metadata import *
+from .scanner import Scanner
+from .runner import Sniffer
+from .main import main, run
 
 __all__ = ['Scanner', 'Sniffer', 'main', 'run']

--- a/sniffer/api.py
+++ b/sniffer/api.py
@@ -1,4 +1,5 @@
 import os,sys
+import collections
 
 __all__ = ['get_files', 'file_validator', 'runnable']
 
@@ -21,7 +22,7 @@ class Wrapper(object):
         self.__name__ = func.__name__
         self.__doc__ = func.__doc__
         
-        if not callable(func):
+        if not isinstance(func, collections.Callable):
             raise TypeError("Given object is not callable.")
     
     def __repr__(self):

--- a/sniffer/broadcasters.py
+++ b/sniffer/broadcasters.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 
 
@@ -11,10 +12,12 @@ class NullEmitter(object):
 class PrinterEmitter(object):
     "Simply emits exit status info to the console/terminal."
     def success(self, sniffer):
-        print sniffer.pass_colors['bg'](sniffer.pass_colors['fg']("In good standing"))
+        print(sniffer.pass_colors['bg'](
+            sniffer.pass_colors['fg']("In good standing")))
 
     def failure(self, sniffer):
-        print sniffer.fail_colors['bg'](sniffer.fail_colors['fg']("Failed - Back to work!"))
+        print(sniffer.fail_colors['bg'](
+            sniffer.fail_colors['fg']("Failed - Back to work!")))
 
 try:
     import pynotify
@@ -46,7 +49,7 @@ try:
             try:
                 self.growl.register()
             except socket.error:
-                print >>sys.stderr, "Failed to connect to growl! :("
+                print("Failed to connect to growl! :(", file=sys.stderr)
                 self.growl = None
 
         def success(self, sniffer):

--- a/sniffer/main.py
+++ b/sniffer/main.py
@@ -1,6 +1,7 @@
 """
 Main runners. Bootloads Sniffer class.
 """
+from __future__ import print_function, absolute_import
 from optparse import OptionParser
 from scanner import Scanner
 from runner import Sniffer, ScentSniffer
@@ -68,13 +69,13 @@ def main(sniffer_instance=None, test_args=(), progname=sys.argv[0], args=sys.arg
     test_args = test_args + tuple(options.test_args)
 
     if options.debug:
-        print "Options:", options
-        print "Test Args:", test_args
+        print("Options:", options)
+        print("Test Args:", test_args)
     try:
-        print "Starting watch..."
+        print("Starting watch...")
         run(sniffer_instance, options.wait_time, options.clear_on_run, test_args, options.debug)
     except KeyboardInterrupt:
-        print "Good bye."
+        print("Good bye.")
     except Exception:
         import traceback
         traceback.print_exc()

--- a/sniffer/runner.py
+++ b/sniffer/runner.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from modules_restore_point import ModulesRestorePoint
 from broadcasters import broadcaster
 from functools import wraps
@@ -9,10 +10,15 @@ import scent_picker
 
 __all__ = ['Sniffer']
 
+try:
+    _ = StandardError
+except NameError:
+    StandardError = Exception
+
 # for debugging
 def echo(text):
     def wrapped(filepath):
-        print text % {'file': filepath}
+        print(text % {'file': filepath})
     return wrapped
 
 class Sniffer(object):
@@ -83,7 +89,7 @@ class Sniffer(object):
         else:
             os.system('clear')
         if prefix:
-            print prefix
+            print(prefix)
 
     def _stop(self):
         """Calls stop() to all scanner in an attempt to quit."""
@@ -117,9 +123,9 @@ class Sniffer(object):
             arguments = [sys.argv[0]] + list(self.test_args)
             return nose.run(argv=arguments)
         except ImportError:
-            print
-            print "*** Nose library missing. Please install it. ***"
-            print
+            print()
+            print("*** Nose library missing. Please install it. ***")
+            print()
             raise
 
 class ScentSniffer(Sniffer):
@@ -140,7 +146,7 @@ class ScentSniffer(Sniffer):
 
     def refresh_scent(self, filepath):
         if self.scent and filepath == self.scent.filename:
-            print "Reloaded Scent:", filepath
+            print("Reloaded Scent:", filepath)
             for s in self._scanners:
                 self.unobserve_scanner(s)
             self.scent = self.scent.reload()
@@ -151,14 +157,14 @@ class ScentSniffer(Sniffer):
     def unobserve_scanner(self, scanner):
         for v in self.scent.validators:
             if self.debug:
-                print "Removed", repr(v)
+                print("Removed", repr(v))
             scanner.remove_validator(v)
 
     def scent_observe_scanner(self, scanner):
         if self.scent:
             for v in self.scent.validators:
                 if self.debug:
-                    print "Added", repr(v)
+                    print("Added", repr(v))
                 scanner.add_validator(v)
 
     def observe_scanner(self, scanner):
@@ -175,10 +181,10 @@ class ScentSniffer(Sniffer):
         Runs the CWD's scent file.
         """
         if not self.scent or len(self.scent.runners) == 0:
-            print "Did not find 'scent.py', running nose:"
+            print("Did not find 'scent.py', running nose:")
             return super(ScentSniffer, self).run()
         else:
-            print "Using scent:"
+            print("Using scent:")
             arguments = [sys.argv[0]] + list(self.test_args)
             return self.scent.run(arguments)
         return True

--- a/sniffer/scanner/__init__.py
+++ b/sniffer/scanner/__init__.py
@@ -6,7 +6,8 @@ It provides a polling technique which is an OS-independent and uses no third-par
 libraries at the cost of performance. The polling technique constantly walks through
 the directory tree to see which files changed, calling os.stat on the files.
 """
-from base import PollingScanner
+from __future__ import absolute_import
+from .base import PollingScanner
 
 __all__ = ['Scanner']
 
@@ -17,9 +18,10 @@ Scanner = PollingScanner
 # Plus, factories remind me a lot of java...
 def _import(module, cls):
     global Scanner
+
     try:
         cls = str(cls)
-        mod = __import__(str(module), globals(), locals(), [cls], -1)
+        mod = __import__(str(module), globals(), locals(), [cls], 1)
         Scanner = getattr(mod, cls)
     except ImportError:
         pass

--- a/sniffer/scanner/base.py
+++ b/sniffer/scanner/base.py
@@ -7,6 +7,7 @@ the directory tree to see which files changed, calling os.stat on the files.
 """
 import os
 import time
+import collections
 
 class BaseScanner(object):
     """
@@ -23,7 +24,7 @@ class BaseScanner(object):
         self._watched_files = {}
 
     def add_validator(self, func):
-        if not callable(func):
+        if not isinstance(func, collections.Callable):
             raise TypeError("Param should return boolean and accept a filename str.")
         self._validators.append(func)
 
@@ -146,7 +147,7 @@ class BaseScanner(object):
         if event_name not in self.ALL_EVENTS:
             raise TypeError('event_name ("%s") can only be one of the following: %s' % \
                             (event_name, repr(self.ALL_EVENTS)))
-        if not callable(func):
+        if not isinstance(func, collections.Callable):
             raise TypeError('func must be callable to be added as an observer.')
         getattr(self._events[event_name], method)(func)
 
@@ -241,7 +242,7 @@ class PollingScanner(BaseScanner):
         self.trigger_init()
         self._scan(trigger=False) # put after the trigger
         if self._warn:
-            print """
+            print("""
 You should install a third-party library so I don't eat CPU.
 Supported libraries are:
   - pyinotify (Linux)
@@ -249,10 +250,10 @@ Supported libraries are:
   - MacFSEvents (OSX)
 
 Use pip or easy_install and install one of those libraries above.
-"""
+""")
         while self._running:
             self._scan()
-            if callable(callback):
+            if isinstance(callback, collections.Callable):
                 callback()
             time.sleep(sleep_time)
 
@@ -282,7 +283,7 @@ Use pip or easy_install and install one of those libraries above.
                         self._watch_file(fpath, trigger)
                         changed = True
             files_seen = set(files_seen)
-            for f in self._watched_files.keys():
+            for f in self._watched_files:
                 if f not in files_seen:
                     self._unwatch_file(f, trigger)
                     changed = True

--- a/sniffer/scanner/fsevents_scanner.py
+++ b/sniffer/scanner/fsevents_scanner.py
@@ -4,7 +4,8 @@ Scanner that relies on the MacFSEvents (OSX) library.
 This is an OS-specific implementation that eliminates the constant polling of the
 directory tree by hooking into OSX's IO events.
 """
-from base import BaseScanner
+from __future__ import absolute_import
+from .base import BaseScanner
 import os
 import fsevents
 import time
@@ -44,9 +45,12 @@ class FSEventsScanner(BaseScanner):
         #
         # So we're silently absorbing all the errors
         try:
-            from cStringIO import StringIO
+            from io import StringIO
         except:
-            from StringIO import StringIO
+            try:
+                from cStringIO import StringIO
+            except:
+                from StringIO import StringIO
         old_err, old_out = sys.stderr, sys.stdout
         sys.stderr, sys.stdout = StringIO(), StringIO()
 

--- a/sniffer/scanner/pyinotify_scanner.py
+++ b/sniffer/scanner/pyinotify_scanner.py
@@ -1,4 +1,5 @@
-from base import BaseScanner
+from __future__ import absolute_import
+from .base import BaseScanner
 import platform
 
 import pyinotify

--- a/sniffer/scanner/pywin_scanner.py
+++ b/sniffer/scanner/pywin_scanner.py
@@ -5,7 +5,8 @@ Requires the pywin32 library
 The code is based off Tim Golden's work:
 http://timgolden.me.uk/python/win32_how_do_i/watch_directory_for_changes.html
 """
-from base import BaseScanner
+from __future__ import absolute_import
+from .base import BaseScanner
 import win32file
 import win32con
 import os

--- a/sniffer/scent_picker.py
+++ b/sniffer/scent_picker.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 g = globals().copy()
 import os, sys, termstyle
 
@@ -16,7 +17,7 @@ class ScentModule(object):
                 self.validators.append(obj)
         self.runners = tuple(self.runners)
         self.validators = tuple(self.validators)
-        print self.validators
+        print(self.validators)
         
     def reload(self):
         try:
@@ -24,8 +25,8 @@ class ScentModule(object):
         except Exception:
             import traceback
             traceback.print_exc()
-            print
-            print "Still using previously valid Scent."
+            print()
+            print("Still using previously valid Scent.")
             return self
     
     def run(self, args):
@@ -37,7 +38,7 @@ class ScentModule(object):
         except Exception:
             import traceback
             traceback.print_exc()
-            print
+            print()
             return False
         
     @property
@@ -65,7 +66,7 @@ def load_file(filename):
     mod_path = os.path.dirname(filename)
     
     global_vars = globals()
-    if mod_name in sys.modules.keys():
+    if mod_name in sys.modules:
         del sys.modules[mod_name]
     if mod_path not in set(sys.modules.keys()):
         sys.path.insert(0, mod_path)


### PR DESCRIPTION
This commit makes sniffer compatible with Python 3 while retaining compatibility with 2.6 and 2.7. With this change, sniffer was incredibly helpful while porting one of my own projects.

I've tested the basics (running a bunch of nose tests with and without pyinotify/fsevents) with Python 2.6 on Debian, 2.7 on Debian, 3.2 on Debian, 2.7 on OS X, and 3.3 on OS X. I haven't had a chance to test on Windows yet. I've used `from __future__ import print_function`, which is only available in Python 2.6 or newer, but it would be possible to port to Python 2.5 by using `sys.`(`stdout`|`stderr`)`.write` or some sort of compatibility hack.
