### PR TITLE
Fix imports for distribution install.

### DIFF
--- a/sniffer/main.py
+++ b/sniffer/main.py
@@ -3,9 +3,9 @@ Main runners. Bootloads Sniffer class.
 """
 from __future__ import print_function, absolute_import
 from optparse import OptionParser
-from scanner import Scanner
-from runner import Sniffer, ScentSniffer
-from metadata import __version__
+from sniffer.scanner import Scanner
+from sniffer.runner import Sniffer, ScentSniffer
+from sniffer.metadata import __version__
 import sys
 
 import colorama

--- a/sniffer/runner.py
+++ b/sniffer/runner.py
@@ -1,12 +1,13 @@
 from __future__ import print_function
-from modules_restore_point import ModulesRestorePoint
-from broadcasters import broadcaster
+from __future__ import absolute_import
+from .modules_restore_point import ModulesRestorePoint
+from .broadcasters import broadcaster
 from functools import wraps
 from termstyle import bg_red, bg_green, white
 import platform
 import os
 import sys
-import scent_picker
+from . import scent_picker
 
 __all__ = ['Sniffer']
 


### PR DESCRIPTION
This commit fixes sniffer after I broke it in commit 4c5afaf9d792d9e3125c1fdadcb20f22a867fb6c.

Since commit 4c5afaf9d792d9e3125c1fdadcb20f22a867fb6c, running sniffer after installing via pip results in an import error due to leftover relative imports. I created created and tested that commit by running `python $PATH_TO_SNIFFER/sniffer/main.py` directly, which allowed some imports to succeed in testing, but fail when sniffer is run from an installed distribution.

This commit fixes the error by correcting the remaining old-style imports in runner.py and main.py. The imports in main.py are made absolute so sniffer can still be run locally during development.

I've tested this by installing sniffer with `pip install https://github.com/wharris/sniffer/archive/fix_imports.zip` and then running `sniffer` (not by running sniffer/main.py directly).
