### PR TITLE
added a passive fault tolerant terminal-notifier emitter

### DIFF
--- a/sniffer/broadcasters.py
+++ b/sniffer/broadcasters.py
@@ -76,6 +76,7 @@ except ImportError:
     GrowlEmitter = NullEmitter
 
 try:
+    import os
     import subprocess
     import nose
     class TerminalNotifierEmitter(object):
@@ -83,22 +84,28 @@ try:
 
         def success(self, sniffer, result):
             try:
-                subprocess.call(["terminal-notifier-success",
-                    "-title", "Sniffer",
-                    "-subtitle", "In good standing",
-                    "-message", "%s specifications" % (result.denominator,)])
+                content = ["terminal-notifier-success",
+                           "-title", "Sniffer",
+                           "-subtitle", "In good standing",
+                           "-message", "%s specifications" % (
+                            result.denominator,)]
+                with open(os.devnull, "w") as f:
+                    subprocess.call(content, stdout=f)
             except Exception, e:
                 # we don't really care if this fails
                 pass
 
         def failure(self, sniffer, result):
             try:
-                subprocess.call(["terminal-notifier-failed",
-                    "-title", "Sniffer",
-                    "-subtitle", "Failed - Back to work!",
-                    "-message", "%s specifications, %s failures" % (
-                        result.denominator,
-                        result.denominator - result.numerator)])
+                content = ["terminal-notifier-failed",
+                           "-title", "Sniffer",
+                           "-subtitle", "Failed - Back to work!",
+                           "-message", "%s specifications, %s failures" % (
+                            result.denominator,
+                            result.denominator - result.numerator)]
+
+                with open(os.devnull, "w") as f:
+                    subprocess.call(content, stdout=f)
             except Exception, e:
                 # we don't really care if this fails
                 pass

--- a/sniffer/broadcasters.py
+++ b/sniffer/broadcasters.py
@@ -4,18 +4,18 @@ import sys
 
 class NullEmitter(object):
     "Emitter that does nothing."
-    def success(self, sniffer):
+    def success(self, sniffer, result=None):
         pass
-    def failure(self, sniffer):
+    def failure(self, sniffer, result=None):
         pass
 
 class PrinterEmitter(object):
     "Simply emits exit status info to the console/terminal."
-    def success(self, sniffer):
+    def success(self, sniffer, result=None):
         print(sniffer.pass_colors['bg'](
             sniffer.pass_colors['fg']("In good standing")))
 
-    def failure(self, sniffer):
+    def failure(self, sniffer, result=None):
         print(sniffer.fail_colors['bg'](
             sniffer.fail_colors['fg']("Failed - Back to work!")))
 
@@ -26,10 +26,10 @@ try:
         def __init__(self):
             pynotify.init('Sniffer')
 
-        def success(self, sniffer):
+        def success(self, sniffer, result=None):
             pynotify.Notification('Sniffer', 'In good standing').show()
 
-        def failure(self, sniffer):
+        def failure(self, sniffer, result=None):
             pynotify.Notification('Sniffer', 'Failed - Back to work!').show()
 
 except ImportError:
@@ -52,7 +52,7 @@ try:
                 print("Failed to connect to growl! :(", file=sys.stderr)
                 self.growl = None
 
-        def success(self, sniffer):
+        def success(self, sniffer, result=None):
             if self.growl:
                 self.growl.notify(
                     noteType="Passes",
@@ -62,7 +62,7 @@ try:
                     priority=1,
                 )
 
-        def failure(self, sniffer):
+        def failure(self, sniffer, result=None):
             if self.growl:
                 self.growl.notify(
                     noteType="Failures",
@@ -77,19 +77,28 @@ except ImportError:
 
 try:
     import subprocess
+    import nose
     class TerminalNotifierEmitter(object):
         "Emits exit status info to OS X terminal notifier"
 
-        def success(self, sniffer):
+        def success(self, sniffer, result):
             try:
-                subprocess.call(["terminal-notifier-success", "-title", "Sniffer", "-message", "In good standing"])
+                subprocess.call(["terminal-notifier-success",
+                    "-title", "Sniffer",
+                    "-subtitle", "In good standing",
+                    "-message", "%s specifications" % (result.denominator,)])
             except Exception, e:
                 # we don't really care if this fails
                 pass
 
-        def failure(self, sniffer):
+        def failure(self, sniffer, result):
             try:
-                subprocess.call(["terminal-notifier-failed", "-title", "Sniffer", "-message", "Failed - Back to work!"])
+                subprocess.call(["terminal-notifier-failed",
+                    "-title", "Sniffer",
+                    "-subtitle", "Failed - Back to work!",
+                    "-message", "%s specifications, %s failures" % (
+                        result.denominator,
+                        result.denominator - result.numerator)])
             except Exception, e:
                 # we don't really care if this fails
                 pass
@@ -103,13 +112,13 @@ class Broadcaster(object):
     def __init__(self, *emitters):
         self.emitters = emitters
 
-    def success(self, sniffer):
+    def success(self, sniffer, result=None):
         for emit in self.emitters:
-            emit.success(sniffer)
+            emit.success(sniffer, result)
 
-    def failure(self, sniffer):
+    def failure(self, sniffer, result=None):
         for emit in self.emitters:
-            emit.failure(sniffer)
+            emit.failure(sniffer, result)
 
 
 broadcaster = Broadcaster(

--- a/sniffer/broadcasters.py
+++ b/sniffer/broadcasters.py
@@ -75,6 +75,29 @@ try:
 except ImportError:
     GrowlEmitter = NullEmitter
 
+try:
+    import subprocess
+    class TerminalNotifierEmitter(object):
+        "Emits exit status info to OS X terminal notifier"
+
+        def success(self, sniffer):
+            try:
+                subprocess.call(["terminal-notifier-success", "-title", "Sniffer", "-message", "In good standing"])
+            except Exception, e:
+                # we don't really care if this fails
+                pass
+
+        def failure(self, sniffer):
+            try:
+                subprocess.call(["terminal-notifier-failed", "-title", "Sniffer", "-message", "Failed - Back to work!"])
+            except Exception, e:
+                # we don't really care if this fails
+                pass
+
+except ImportError:
+    TerminalNotifierEmitter = NullEmitter
+
+
 
 class Broadcaster(object):
     def __init__(self, *emitters):
@@ -93,4 +116,5 @@ broadcaster = Broadcaster(
     PrinterEmitter(),
     GrowlEmitter(),
     PynotifyEmitter(),
+    TerminalNotifierEmitter()
 )

--- a/sniffer/runner.py
+++ b/sniffer/runner.py
@@ -100,10 +100,11 @@ class Sniffer(object):
     def _run(self):
         """Calls self.run() and wraps for errors."""
         try:
-            if self.run():
-                broadcaster.success(self)
+            result = self.run()
+            if result:
+                broadcaster.success(self, result)
             else:
-                broadcaster.failure(self)
+                broadcaster.failure(self, result)
         except StandardError:
             import traceback
             traceback.print_exc()


### PR DESCRIPTION
Hi,

just created a passive emitter for Mac OS X terminal-notifier and I thought you might want to include it in the next release. Tested this on both Mac OS X 10.8 Mountain Lion and 10.9 Mavericks and it seems to work perfectly.

kind regards,
Bjarki (codehugger)