### PR TITLE
Recover from emitter errors

### DIFF
--- a/sniffer/broadcasters.py
+++ b/sniffer/broadcasters.py
@@ -82,15 +82,29 @@ except ImportError:
 
 class Broadcaster(object):
     def __init__(self, *emitters):
-        self.emitters = emitters
+        self.emitters = list(emitters)
 
     def success(self, sniffer):
-        for emit in self.emitters:
-            emit.success(sniffer)
+        for emit in list(self.emitters):
+            try:
+                emit.success(sniffer)
+            except Exception as e:
+                self.remove(emit, str(e))
 
     def failure(self, sniffer):
-        for emit in self.emitters:
-            emit.failure(sniffer)
+        for emit in list(self.emitters):
+            try:
+                emit.failure(sniffer)
+            except Exception as e:
+                self.remove(emit, str(e))
+
+    def remove(self, emitter, why):
+        self.emitters.remove(emitter)
+
+        print(why, file=sys.stderr)
+
+        if not self.emitters:
+            raise Exception('No emitters available')
 
 
 broadcaster = Broadcaster(


### PR DESCRIPTION
PyNotify raises an error when showing a message if no service is available.  Instead of dying when an emitter raises, that emitter is removed.  If the last emitter is removed an exception is raised (because there would be no way to monitor test results).

This solution might be worse than checking that a libnotify service exists and using a NullEmitter if not.  A quick google didn't turn up any documentation for pynotify so I didn't look into this.

A third possibility for my use-case is adding a --no-libnotify argument.