### PR TITLE
Adds select_runnable decorator to api and bumps to version 0.3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,16 +59,16 @@ your current working directory. Here's an example of what you can do so far::
 
   from sniffer.api import * # import the really small API
   import os, termstyle
-  
+
   # you can customize the pass/fail colors like this
   pass_fg_color = termstyle.green
   pass_bg_color = termstyle.bg_default
   fail_fg_color = termstyle.red
   fail_bg_color = termstyle.bg_default
-  
+
   # All lists in this variable will be under surveillance for changes.
   watch_paths = ['.', 'tests/']
-  
+
   # this gets invoked on every file that gets changed in the directory. Return
   # True to invoke any runnable functions, False otherwise.
   #
@@ -77,7 +77,7 @@ your current working directory. Here's an example of what you can do so far::
   @file_validator
   def py_files(filename):
       return filename.endswith('.py') and not os.path.basename(filename).startswith('.')
-  
+
   # This gets invoked for verification. This is ideal for running tests of some sort.
   # For anything you want to get constantly reloaded, do an import in the function.
   #
@@ -91,8 +91,44 @@ your current working directory. Here's an example of what you can do so far::
       import nose
       return nose.run(argv=list(args))
 
-And that's it. Nothing too fancy shmanshe. You can have multiple file_validator and
+And that's the basic case. Nothing too fancy shmanshe. You can have multiple file_validator and
 runnable decorators if you want.
+
+There is also support for selecting a runnable function by file validator.
+Useful if you want to run nose for Python files, mocha for JavaScript files,
+and csslint for CSS. Or any other combination you can come up with. For
+example::
+
+    # Here we instruct the 'python_tests' runnable to be kicked off
+    # when a .py file is changed
+    @select_runnable('python_tests')
+    @file_validator
+    def py_files(filename):
+        return filename.endswith('.py') and not os.path.basename(filename).startswith('.')
+
+
+    # Here we instruct the 'javascript_tests' runnable to be kicked off
+    # when a .js file is changed
+    @select_runnable('javascript_tests')
+    @file_validator
+    def js_files(filename):
+        return filename.endswith('.js') and not os.path.basename(filename).startswith('.')
+
+
+    @runnable
+    def python_tests(*args):
+        import nose
+        return nose.run(argv=list(args))
+
+
+    @runnable
+    def javascript_tests(*args):
+        command = "mocha tests/js-tests.js"
+        return call(command, shell=True) == 0
+
+This will run the nose for modifications to Python files and mocha when
+JavaScript files are changed.
+
 
 Other Uses
 ==========

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 # will fail to install via pip/easy_install
 #from sniffer.metadata import __version__, __author__, __author_email__
 
-__version__, __author__, __author_email__ = "0.3.3", "Jeff Hui", "jeff@jeffhui.net"
+__version__, __author__, __author_email__ = "0.3.4", "Jeff Hui", "jeff@jeffhui.net"
 
 setup(
     name='sniffer',

--- a/sniffer/api.py
+++ b/sniffer/api.py
@@ -1,7 +1,7 @@
 import os
 import collections
 
-__all__ = ['get_files', 'file_validator', 'runnable']
+__all__ = ['get_files', 'file_validator', 'runnable', 'select_runnable']
 
 
 def get_files(exts=('py',), dirname=None):
@@ -32,6 +32,19 @@ class Wrapper(object):
 
     def __call__(self, *args, **kwargs):
         return self.func(*args, **kwargs)
+
+
+def select_runnable(runnable):
+    def decorator(func):
+        if (not isinstance(func, Wrapper) or
+            func.scent_api_type != 'file_validator'):
+            raise TypeError(
+                'select_runnable must be the outermost decorator on a '
+                'file_validator'
+            )
+        func.runnable = runnable
+        return func
+    return decorator
 
 
 def file_validator(func):

--- a/sniffer/main.py
+++ b/sniffer/main.py
@@ -35,9 +35,12 @@ def run(sniffer_instance=None, wait_time=0.5, clear=True, args=(),
         sniffer_instance = ScentSniffer()
 
     if debug:
-        scanner = Scanner(sniffer_instance.watch_paths, logger=sys.stdout)
+        scanner = Scanner(
+            sniffer_instance.watch_paths,
+            scent=sniffer_instance.scent, logger=sys.stdout)
     else:
-        scanner = Scanner(sniffer_instance.watch_paths)
+        scanner = Scanner(
+            sniffer_instance.watch_paths, scent=sniffer_instance.scent)
     #sniffer = sniffer_cls(tuple(args), clear, debug)
     sniffer_instance.set_up(tuple(args), clear, debug)
 

--- a/sniffer/scent_picker.py
+++ b/sniffer/scent_picker.py
@@ -14,6 +14,7 @@ class ScentModule(object):
         self.filename = filename
         self.validators = []
         self.runners = []
+        self.runner_name = None
         for name in dir(self.mod):
             obj = getattr(self.mod, name)
             type = getattr(obj, 'scent_api_type', None)
@@ -23,7 +24,6 @@ class ScentModule(object):
                 self.validators.append(obj)
         self.runners = tuple(self.runners)
         self.validators = tuple(self.validators)
-        print(self.validators)
 
     def reload(self):
         try:
@@ -37,7 +37,7 @@ class ScentModule(object):
 
     def run(self, args):
         try:
-            for r in self.runners:
+            for r in self.get_runners():
                 if not r(*args):
                     return False
             return True
@@ -46,6 +46,17 @@ class ScentModule(object):
             traceback.print_exc()
             print()
             return False
+
+    def set_runner(self, runner_name):
+        self.runner_name = runner_name
+
+    def get_runners(self):
+        if self.runner_name:
+            return filter(
+                lambda f: f.__name__ == self.runner_name,
+                self.runners
+            )
+        return self.runners
 
     @property
     def fg_pass(self):

--- a/sniffer/tests/scent_file.py
+++ b/sniffer/tests/scent_file.py
@@ -1,0 +1,23 @@
+from sniffer.api import *
+
+
+@select_runnable('execute_type1')
+@file_validator
+def type1_files(filename):
+    return filename.endswith('.type1')
+
+
+@select_runnable('execute_type2')
+@file_validator
+def type2_files(filename):
+    return filename.endswith('.type2')
+
+
+@runnable
+def execute_type1(mock, *args):
+    mock('type1')
+
+
+@runnable
+def execute_type2(mock, *args):
+    mock('type2')

--- a/sniffer/tests/test_api.py
+++ b/sniffer/tests/test_api.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+from ..api import file_validator, select_runnable
+
+
+class SelectRunnableDecorator(TestCase):
+
+    def test_decorator_adds_runnable_name_to_wrapped_func(self):
+
+        def ex_validator():
+            pass
+
+        validator = select_runnable('tagged')(file_validator(ex_validator))
+
+        self.assertEqual(validator.runnable, 'tagged')
+
+
+
+

--- a/sniffer/tests/test_scent_module.py
+++ b/sniffer/tests/test_scent_module.py
@@ -1,0 +1,33 @@
+from unittest import TestCase
+from ..scent_picker import load_file
+from ..scanner.base import BaseScanner
+
+
+class ScentModuleTest(TestCase):
+
+    def test_set_runner_and_get_runner_methods(self):
+        scent = load_file('sniffer/tests/scent_file.py')
+        self.assertEqual(scent.get_runners(), scent.runners)
+
+        scent.set_runner('execute_type1')
+        self.assertEqual(scent.get_runners(), (scent.runners[0],))
+
+        scent.set_runner('execute_type2')
+        self.assertEqual(scent.get_runners(), (scent.runners[1],))
+
+    def test_scent_module_interaction_with_scanner(self):
+        scent = load_file('sniffer/tests/scent_file.py')
+        scanner = BaseScanner([], scent)
+
+        for v in scent.validators:
+            scanner.add_validator(v)
+
+        self.assertTrue(scanner.is_valid_type('file.type1'))
+        self.assertTrue(scanner.is_valid_type('file.type2'))
+        self.assertFalse(scanner.is_valid_type('file.negative'))
+
+
+
+
+
+


### PR DESCRIPTION
The select_runnable decorator allows the user to pick which runnable is
run for each type of file validator. This means that you can run
JavaScript unit tests when '.js' files are modified and Python tests
when you edit a '.py' file. When the select_runnable decorator is used
the behaviour of sniffer changes slightly in that all file validators
are attempted and if one of them returns True the associated runnable is
then executed.