### PR TITLE
also react to moves

### DIFF
--- a/sniffer/scanner/pyinotify_scanner.py
+++ b/sniffer/scanner/pyinotify_scanner.py
@@ -26,6 +26,16 @@ class EventHandler(pyinotify.ProcessEvent):
         if self._scanner.is_valid_type(event.pathname):
             self._scanner.trigger_modified(event.pathname)
 
+    def process_IN_MOVED_FROM(self, event):
+        if self._scanner.is_valid_type(event.pathname):
+            self._scanner.trigger_deleted(event.pathname)
+
+    def process_IN_MOVED_TO(self, event):
+        print('got moved to')
+        #self._process('modified', event.pathname)
+        if self._scanner.is_valid_type(event.pathname):
+            self._scanner.trigger_modified(event.pathname)
+
 
 class PyINotifyScanner(BaseScanner):
     """
@@ -45,7 +55,8 @@ class PyINotifyScanner(BaseScanner):
         handler = EventHandler(self)
 
         notifier = pyinotify.Notifier(self._watcher, handler)
-        mask = pyinotify.IN_DELETE | pyinotify.IN_CREATE | pyinotify.IN_MODIFY
+        mask = pyinotify.IN_DELETE | pyinotify.IN_CREATE | pyinotify.IN_MODIFY | \
+            pyinotify.IN_MOVED_TO | pyinotify.IN_MOVED_TO
         for path in self.paths:
             self._watcher.add_watch(path, mask, rec=True, auto_add=True,
                                     exclude_filter=self.is_valid_type)


### PR DESCRIPTION
My editor of choice (Sublime Tet) does not modify files in place, but saves a new copy and then moves it in place, atomically. Makes sense, I guess, but sniffer failed to react to these changes.

The patch simply makes react to `MOVED_FROM` and `MOVED_TO` events in the same way the corresponding `DELETE` and `MODIFIED` do. For some files, it may be better to use `trigger_created`, but I guess I'm not the only one who will get to that point more often with modified files.