### PR TITLE
Native OS X notifications using osxnotify-python and libosxnotify

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ third-party library can help fix the problem. The library is dependent on your o
 If you want support for other notification systems, you can install:
 
 - gntp_ for Growl_ support (Mac OS X).
+- osxnotify_ and libosxnotify_ for native OS X notifications (Max OS X 10.9.4 and newer)
 - py-notify_ for LibNotify_ support (Linux).
 
 .. [#] This has been resolved in subsequent autonose versions, using watchdog.
@@ -57,6 +58,8 @@ If you want support for other notification systems, you can install:
 .. _Growl: http://growl.info
 .. _py-notify: http://home.gna.org/py-notify
 .. _LibNotify: http://developer-next.gnome.org/libnotify/
+.. _osxnotify: https://github.com/tomekwojcik/osxnotify-python
+.. _libosxnotify: https://github.com/tomekwojcik/libosxnotify
 
 Advanced Usage
 --------------

--- a/sniffer/broadcasters.py
+++ b/sniffer/broadcasters.py
@@ -80,6 +80,29 @@ except ImportError:
     GrowlEmitter = NullEmitter
 
 
+try:
+    import osxnotify
+
+    class OSXNotifyEmitter(object):
+        """Emits exit status info to osxnotify."""
+        def success(self, sniffer):
+            osxnotify.notify(
+                title="Sniffer",
+                subtitle="Passes",
+                informative_text="In good standing!"
+            )
+
+        def failure(self, sniffer):
+            osxnotify.notify(
+                title="Sniffer",
+                subtitle="Failures",
+                informative_text="Back to wrok!"
+            )
+
+except ImportError:
+    OSXNotifyEmitter = NullEmitter
+
+
 class Broadcaster(object):
     def __init__(self, *emitters):
         self.emitters = list(emitters)
@@ -110,5 +133,6 @@ class Broadcaster(object):
 broadcaster = Broadcaster(
     PrinterEmitter(),
     GrowlEmitter(),
+    OSXNotifyEmitter(),
     PynotifyEmitter(),
 )


### PR DESCRIPTION
I wanted to use Growl for notifications, but Growl is apparently not free anymore, so I used [libosxnotify](https://github.com/tomekwojcik/libosxnotify) and [osxnotify-python](https://github.com/tomekwojcik/osxnotify-python) to quickly add native notifications for OS X instead.

Neither is stable, but just like Growl and py-notify, nothing happens if they are not installed, so it is an opt-in functionality.